### PR TITLE
Fix parsing of `+?` and `*?` suffixes

### DIFF
--- a/src/Antlr4Ast.Tests/Snapshots/TestParser.VerifyCSharpLexer.verified.txt
+++ b/src/Antlr4Ast.Tests/Snapshots/TestParser.VerifyCSharpLexer.verified.txt
@@ -20,7 +20,7 @@ EMPTY_DELIMITED_DOC_COMMENT
   ;
 
 DELIMITED_DOC_COMMENT
-  : '/**' ~ '/' .* '*/' -> channel(COMMENTS_CHANNEL)
+  : '/**' ~ '/' .*? '*/' -> channel(COMMENTS_CHANNEL)
   ;
 
 SINGLE_LINE_COMMENT
@@ -28,7 +28,7 @@ SINGLE_LINE_COMMENT
   ;
 
 DELIMITED_COMMENT
-  : '/*' .* '*/' -> channel(COMMENTS_CHANNEL)
+  : '/*' .*? '*/' -> channel(COMMENTS_CHANNEL)
   ;
 
 WHITESPACES

--- a/src/Antlr4Ast.Tests/Snapshots/TestParser.VerifyLexBasicFile.verified.txt
+++ b/src/Antlr4Ast.Tests/Snapshots/TestParser.VerifyLexBasicFile.verified.txt
@@ -54,11 +54,11 @@ fragment Vws
   ;
 
 fragment BlockComment
-  : '/*' .* ( '*/' | EOF )
+  : '/*' .*? ( '*/' | EOF )
   ;
 
 fragment DocComment
-  : '/**' .* ( '*/' | EOF )
+  : '/**' .*? ( '*/' | EOF )
   ;
 
 fragment LineComment

--- a/src/Antlr4Ast.Tests/Snapshots/TestParser.VerifyMergeGrammar.verified.txt
+++ b/src/Antlr4Ast.Tests/Snapshots/TestParser.VerifyMergeGrammar.verified.txt
@@ -659,11 +659,11 @@ fragment Vws
   ;
 
 fragment BlockComment
-  : '/*' .* ( '*/' | EOF )
+  : '/*' .*? ( '*/' | EOF )
   ;
 
 fragment DocComment
-  : '/**' .* ( '*/' | EOF )
+  : '/**' .*? ( '*/' | EOF )
   ;
 
 fragment LineComment

--- a/src/Antlr4Ast/InternalAntlr4Visitor.cs
+++ b/src/Antlr4Ast/InternalAntlr4Visitor.cs
@@ -735,7 +735,7 @@ internal sealed class InternalAntlr4Visitor : ANTLRv4ParserBaseVisitor<SyntaxNod
     
     private static void ApplySuffix(ANTLRv4Parser.EbnfSuffixContext suffix, SyntaxElement node)
     {
-        var delta = suffix.QUESTION().Length == 2 ? 3 : 0;
+        var delta = suffix.children.Count == 2 ? 3 : 0;
         node.Suffix = (suffix.PLUS() != null ? SuffixKind.Plus : suffix.STAR() != null ? SuffixKind.Star : SuffixKind.Optional) + delta;
     }
 


### PR DESCRIPTION
This PR fixes the issue of `+?` and `*?` being incorrectly classified as `SuffixKind.Plus` and `.Star`, because the code in `InternalAntlr4Visitor.ApplySuffix` looks for 2 `QUESTION` tokens):

```cs
var delta = suffix.QUESTION().Length == 2 ? 3 : 0;
```

The simplest way to fix this is to check for the total number of children (tokens) instead:

```cs
var delta = suffix.children.Count == 2 ? 3 : 0;
```

One possibly cleaner alternative would be to add a label to the optional `QUESTION` token in the grammar and then check for the presence of the labeled token to determine if this is a greedy or lazy (non-greedy) suffix.